### PR TITLE
Docs: clarify migrations are required

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Flowstate/
    pip install -r requirements.txt
    alembic upgrade head
    ```
+   - Note: the API startup does not auto-create tables; migrations are the source of truth.
 
 5. **Run**
    ```bash


### PR DESCRIPTION
Add a short note in README setup that API startup does not auto-create tables and Alembic migrations are the source of truth.